### PR TITLE
Use Node 20.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Run tasks
         run: |
           npm ci

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Apk Info Action'
+name: 'Apk Info Action for ab'
 description: 'This GitHub Actions gets information of Android apk file.'
 author: 'Hiroyuki Kusu'
 branding:
@@ -38,5 +38,5 @@ outputs:
   result:
     description: '`success` or `failure` is set.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Because node 16 will reach EOL soon.

See also: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/